### PR TITLE
fix state variable not accessed atomically

### DIFF
--- a/Rx/v2/src/rxcpp/operators/rx-merge.hpp
+++ b/Rx/v2/src/rxcpp/operators/rx-merge.hpp
@@ -117,7 +117,7 @@ struct merge
             observable<source_value_type, source_operator_type> source;
             // on_completed on the output must wait until all the
             // subscriptions have received on_completed
-            int pendingCompletions;
+            std::atomic<int> pendingCompletions;
             coordinator_type coordinator;
             output_type out;
         };


### PR DESCRIPTION
Hi, this fixes the merge operator not completing correctly in multithreading scenarios.